### PR TITLE
Update for current fonttools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ snafu = "0.6.10"
 uuid = { version = "0.8", features = ["v4"] }
 shrinkwraprs = "0.3.0"
 fonttools = { path = "../fonttools-rs", features = ["rayon"], version = "0" }
-norad = { version = "0.6.0", git="https://github.com/linebender/norad", features = ["rayon", "kurbo"]}
+norad = { version = "0.6", features = ["rayon", "kurbo"]}
 designspace = { path = "../fonttools-rs/crates/designspace", features = ["norad"], version = "0" }
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,9 +1,9 @@
+use std::collections::HashMap;
+
 use crate::i18ndictionary::I18NDictionary;
 use crate::BabelfontError;
-use fonttools::tables::fvar::VariationAxisRecord;
-use fonttools::types::Tag;
-use std::collections::HashMap;
-use std::convert::TryInto;
+
+use fonttools::{tables::fvar::VariationAxisRecord, types::Tag};
 use uuid::Uuid;
 
 #[derive(Debug)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-pub type Tag = [u8; 4];
-
 #[derive(Debug, Copy, Clone)]
 pub struct Position {
     pub x: i32,

--- a/src/convertors/designspace.rs
+++ b/src/convertors/designspace.rs
@@ -1,13 +1,13 @@
+use std::fs::File;
+use std::path::PathBuf;
+
 use crate::convertors::ufo::load_font_info;
 use crate::convertors::ufo::load_glyphs;
 use crate::convertors::ufo::load_master_info;
 use crate::convertors::ufo::norad_glyph_to_babelfont_layer;
-use std::fs::File;
-use std::path::PathBuf;
+use crate::{Axis, BabelfontError, Font, Location, Master};
 
 use designspace::{Axis as DSAxis, Designspace, Instance as DSInstance};
-
-use crate::{Axis, BabelfontError, Font, Location, Master};
 
 pub fn load(path: PathBuf) -> Result<Font, BabelfontError> {
     let ds_file = File::open(path.clone()).map_err(|source| BabelfontError::IO {

--- a/src/convertors/glyphs3.rs
+++ b/src/convertors/glyphs3.rs
@@ -8,9 +8,9 @@ use crate::{
     Axis, BabelfontError, Component, Font, Glyph, Guide, Instance, Layer, Location, Master, Node,
     NodeType, Path, Position, Shape,
 };
+use fonttools::types::Tag;
 use openstep_plist::Plist;
 use std::collections::HashMap;
-use std::convert::TryInto;
 
 use chrono::TimeZone;
 use lazy_static::lazy_static;
@@ -503,7 +503,7 @@ fn load_properties(font: &mut Font, plist: &Plist) {
                                 if l.len() != 4 {
                                     continue;
                                 };
-                                let l = l.as_bytes()[0..4].try_into().unwrap();
+                                let l = Tag::from_raw(l.as_bytes()).unwrap();
                                 val.0.insert(l, v.to_string());
                             }
                         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,5 +34,3 @@ pub enum BabelfontError {
     #[snafu(display("Ill-constructed path"))]
     BadPath,
 }
-
-type Result<T, E = BabelfontError> = std::result::Result<T, E>;

--- a/src/font.rs
+++ b/src/font.rs
@@ -11,10 +11,14 @@ use chrono::Local;
 use fonttools::font::Font as FTFont;
 use fonttools::otvar::Location as OTVarLocation;
 use fonttools::otvar::{NormalizedLocation, VariationModel};
-use fonttools::tables::avar::{avar, SegmentMap};
-use fonttools::tables::fvar::{fvar, InstanceRecord, VariationAxisRecord};
-use fonttools::tables::name::NameRecord;
-use fonttools::types::Tag;
+use fonttools::{
+    tables::{
+        avar::{avar, SegmentMap},
+        fvar::{fvar, InstanceRecord, VariationAxisRecord},
+        name::NameRecord,
+    },
+    types::Tag,
+};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
@@ -217,10 +221,11 @@ impl Font {
                 ix,
                 instance.style_name.default().expect("Bad instance name"),
             ));
-            let mut ir = InstanceRecord {
+            let ir = InstanceRecord {
                 subfamilyNameID: ix,
                 coordinates: self.location_to_tuple(&instance.location),
                 postscriptNameID: None,
+                flags: 0,
             };
             ix += 1;
             // if let Some(psname) = &instance.postscriptfontname {
@@ -239,14 +244,7 @@ impl Font {
         }
         font.tables.insert(fvar { axes, instances });
 
-        // Handle avar here
-        let avar_table = avar {
-            majorVersion: 1,
-            minorVersion: 0,
-            reserved: 0,
-            axisSegmentMaps: maps,
-        };
-        font.tables.insert(avar_table);
+        font.tables.insert(avar { maps });
         font.tables.insert(name);
 
         Ok(())

--- a/src/i18ndictionary.rs
+++ b/src/i18ndictionary.rs
@@ -1,7 +1,10 @@
-use crate::common::Tag;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
+
+use fonttools::types::Tag;
+
+const DFLT: Tag = fonttools::tag!("dflt");
 
 pub struct I18NDictionary(pub HashMap<Tag, String>);
 
@@ -15,7 +18,7 @@ impl I18NDictionary {
     }
 
     pub fn set_default(&mut self, s: String) {
-        self.0.insert(*b"dflt", s);
+        self.0.insert(DFLT, s);
     }
 }
 
@@ -35,7 +38,7 @@ impl Debug for I18NDictionary {
 impl Into<I18NDictionary> for String {
     fn into(self) -> I18NDictionary {
         let mut f = I18NDictionary::new();
-        f.0.insert(*b"dflt", self);
+        f.0.insert(DFLT, self);
         f
     }
 }
@@ -43,7 +46,7 @@ impl Into<I18NDictionary> for String {
 impl Into<I18NDictionary> for &str {
     fn into(self) -> I18NDictionary {
         let mut f = I18NDictionary::new();
-        f.0.insert(*b"dflt", self.to_string());
+        f.0.insert(DFLT, self.to_string());
         f
     }
 }
@@ -51,7 +54,7 @@ impl Into<I18NDictionary> for &str {
 impl Into<I18NDictionary> for &String {
     fn into(self) -> I18NDictionary {
         let mut f = I18NDictionary::new();
-        f.0.insert(*b"dflt", self.to_string());
+        f.0.insert(DFLT, self.to_string());
         f
     }
 }


### PR DESCRIPTION
No functional change: this addresses some renames/api changes,
and does a bit of cleanup.


This is all just me trying to get fonticulus working with fea-rs :)


Also: this project should probably reference fonttools by git rev (in cargo.toml), this way it won't break anytime you have a different local branch checked out there, or otherwise make changes. (this isn't a problem for separate crates in the same repo, but for crates in different repos it's a pain)