### PR TITLE
Preserve component transform precision during interpolation

### DIFF
--- a/babelfont/src/interpolate.rs
+++ b/babelfont/src/interpolate.rs
@@ -4,7 +4,7 @@ use crate::{common::decomposition::DecomposedAffine, BabelfontError, Layer, Path
 use fontdrasil::{
     coords::{DesignSpace, Location, NormalizedSpace},
     types::Axes,
-    variations::VariationModel,
+    variations::{RoundingBehaviour, VariationModel},
 };
 
 pub(crate) fn interpolate_layer(
@@ -197,7 +197,8 @@ impl Shape {
                         });
                     }
                 }
-                let deltas = model.deltas(&position_lists)?;
+                let deltas =
+                    model.deltas_with_rounding(&position_lists, RoundingBehaviour::None)?;
                 let interpolated_params = model.interpolate_from_deltas(target_location, &deltas);
                 let new_component = crate::shape::Component {
                     reference: c.reference.clone(),


### PR DESCRIPTION
Problem: component transform interpolation used rounded variation deltas, which truncated floating values (for example π≈3.14) and caused visible rotation/transform errors.

Fix: switch component interpolation to deltas_with_rounding(..., RoundingBehaviour::None) and import RoundingBehaviour accordingly.

Result: component transforms retain floating-point precision in live interpolation, avoiding quantization artifacts.