### PR TITLE
Preserve omitted component alignment

### DIFF
--- a/babelfont/src/shape.rs
+++ b/babelfont/src/shape.rs
@@ -507,10 +507,22 @@ mod glyphs {
                 order: TransformOrder::Glyphs,
             };
             let mut format_specific = FormatSpecific::default();
-            format_specific.insert_if_ne_json(
+            // glyphslib 0.2.5+ uses a custom Deserialize that always defaults
+            // to -1 (component_alignment_disabled()) when alignment is absent
+            // from the source file, with an alignment_explicit flag.
+            //
+            // In Glyphs.app, components without explicit alignment participate
+            // in automatic composition by default (alignment = 0). The
+            // alignment_explicit flag lets us restore the pre-0.2.5 behavior
+            // where serde default (0) covered that case. Only skip storing
+            // when alignment was explicitly set to -1 (disabled).
+            format_specific.insert_json(
                 KEY_ALIGNMENT,
-                &val.alignment,
-                &-1, // default value
+                &(if val.alignment_explicit {
+                    val.alignment
+                } else {
+                    0i8 // not explicitly set → default to auto-aligned
+                }),
             );
             format_specific.insert_nonempty_json(KEY_ATTR, &val.attr);
             format_specific.insert_some_json(KEY_COMPONENT_ANCHOR, &val.anchor);
@@ -551,6 +563,7 @@ mod glyphs {
                     .and_then(|v| v.as_i64())
                     .map(|s| s as i8)
                     .unwrap_or(-1),
+                alignment_explicit: val.format_specific.contains_key(KEY_ALIGNMENT),
                 anchor: val.format_specific.get_optionstring(KEY_COMPONENT_ANCHOR),
                 attr: val.format_specific.get_json(KEY_ATTR),
                 smart_component_location: val


### PR DESCRIPTION
This is the missing babelfont-rs reaction to https://github.com/simoncozens/glyphslib-rs/pull/2

# Consume glyphslib's alignment_explicit to preserve component alignment semantics

## Problem

Before glyphslib 0.2.5, when a component in a .glyphs file had no
`alignment` key, serde would deserialize the field as 0 (the Rust
default for i8). This made two semantically distinct cases
indistinguishable:

  (a) alignment was never authored → Glyphs.app defaults to
      auto-aligned (0)
  (b) alignment was explicitly set to 0 → must be preserved and
      roundtripped

As a result, components that were manually positioned (no alignment)
could be silently re-aligned on subsequent compilation, breaking
the user's explicit positioning.

## glyphslib fix (PR #..., commit 5b4b4a3)

glyphslib 0.2.5 replaced derived serde on glyphs3::Component with
custom Serialize/Deserialize impls and a private
`alignment_explicit: bool` flag:

  Source file          | Internal | Explicit? | Serialize
  ---------------------|----------|-----------|----------
  alignment omitted    | -1       | false     | omitted
  alignment = -1       | -1       | true      | written
  alignment = 0        |  0       | true      | written
  alignment = 1 | 3    |  1 | 3   | true      | written

This gives downstream consumers the signal they need to choose the
correct semantic value.

## babelfont consumption (this change)

This commit consumes the new signal to implement the intended
Glyphs.app behavior in babelfont's model:

**On load** (glyphslib → FormatSpecific):
- If `alignment_explicit` is false (omitted in source → glyphslib
  defaults to -1): store 0 in FormatSpecific — the Glyphs.app
  default of auto-aligned.
- If `alignment_explicit` is true: store the actual authored value
  verbatim, including -1 (explicitly disabled alignment).

Previously the code used `insert_if_ne_json(key, &val, &-1)` which
skipped storing the value when it equalled the supplied default (-1).
This was the old approximation: it accidentally treated omitted and
explicit -1 identically, and had no way to represent "was omitted,
was 0" vs "was explicit 0".

**On save** (FormatSpecific → glyphslib):
- Propagate `alignment_explicit` based on whether KEY_ALIGNMENT
  exists in FormatSpecific. Since babelfont's own load always
  inserts KEY_ALIGNMENT, every value it holds is treated as explicit
  on save — which is correct for a model that has already resolved
  defaults.

## Why both layers are necessary

glyphslib is the parser — it must preserve file-level fidelity
(was the key there or not?). babelfont is the model — it must
translate that file-level signal into domain-level meaning
(what alignment value does the user actually intend?). Neither can
do the job alone: glyphslib lacks the domain knowledge to resolve
"omitted → 0", and babelfont would be guessing without glyphslib's
explicit/implicit signal.