### PR TITLE
fontforge: derive unitsPerEm from the SFD Ascent + Descent

### DIFF
--- a/babelfont/src/convertors/fontforge.rs
+++ b/babelfont/src/convertors/fontforge.rs
@@ -707,6 +707,23 @@ impl SfdParser {
             }
         }
 
+        // FontForge SFD defines the em square as Ascent + Descent. The font model
+        // defaults `upm` to 1000, which is wrong for any SFD whose em != 1000 (e.g.
+        // 1024 / 2048): outline coordinates are read at the SFD's real em scale, so a
+        // stale upm=1000 would leave them unscaled and render the font at the wrong
+        // size. Derive upm from the parsed Ascender + Descender metrics (from the SFD
+        // Ascent/Descent lines). `desc.abs()` keeps this correct regardless of whether
+        // Descent is stored as the SFD's positive value or later negated.
+        if let (Some(&asc), Some(&desc)) = (
+            self.font.masters[0].metrics.get(&MetricType::Ascender),
+            self.font.masters[0].metrics.get(&MetricType::Descender),
+        ) {
+            let em = asc + desc.abs();
+            if em > 0 {
+                self.font.upm = em as u16;
+            }
+        }
+
         // Now parse glyphs if present
         if let Some(chars) = char_data {
             self.parse_chars(&chars, &master_id)?;


### PR DESCRIPTION
## Problem

The FontForge SFD convertor never sets `Font.upm`, so it stays at the model
default of **1000**. FontForge defines the em square as `Ascent + Descent`,
which for many SFDs is not 1000 (commonly 1024 or 2048). Outline coordinates
are read at the SFD's real scale, so a converted `.glyphs` ends up declaring
`unitsPerEm = 1000` while its coordinates are e.g. 2048-unit — and the
generated font renders at the wrong size (~2x for a 2048-em source,
+2.4% for 1024, etc.).

## Fix

After the SFD header is parsed, derive `upm` from the parsed Ascender +
Descender metrics (which come from the SFD `Ascent:` / `Descent:` lines):

```
upm = Ascent + |Descent|
```

`desc.abs()` keeps it correct whether Descent is stored as the SFD's positive
value or later negated. It falls back to the existing default when those
metrics are absent.

## Effect

Round-tripping an SFD => `.glyphs` => TTF now preserves the source em, so the
built font matches the size of the original. Verified on real Google Fonts SFD
sources across em sizes 1024, 2048 and 2218: after the fix the built output is
metrically faithful to the shipped binaries (advance widths match ~99-100%),
whereas before it rendered scaled by `em / 1000`.