### PR TITLE
Add load_with_options: partial loading and per-source failure reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "paste",
+ "plist",
  "pretty_assertions",
  "reactive_stores",
  "regex",

--- a/babelfont/Cargo.toml
+++ b/babelfont/Cargo.toml
@@ -34,7 +34,7 @@ default = [
 ]
 vfb = ["dep:vfbreader"]
 glyphs = ["dep:glyphslib"]
-ufo = ["dep:norad"]
+ufo = ["dep:norad", "dep:plist"]
 fontra = []
 robocjk = []
 fontlab = []
@@ -55,6 +55,7 @@ reactive = ["dep:reactive_stores"]
 chrono = { version = "0.4.3", features = ["serde"] }
 glyphslib = { version = "0.2.6", optional = true }
 norad = { version = "0.17.0", features = ["kurbo"], optional = true }
+plist = { version = "1", optional = true }
 log = { workspace = true }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/babelfont/src/convertors/designspace.rs
+++ b/babelfont/src/convertors/designspace.rs
@@ -24,11 +24,28 @@ pub const STYLENAME_KEY: &str = "norad.designspace.style";
 
 use crate::{
     convertors::ufo::{load_master_info, norad_glyph_to_babelfont_layer},
-    Axis, BabelfontError, Font, Master,
+    Axis, BabelfontError, Font, LoadOptions, LoadResult, Master, SourceLoadFailure,
 };
 
 /// Load a DesignSpace document and all referenced UFOs into a Babelfont Font
 pub fn load(path: PathBuf) -> Result<Font, BabelfontError> {
+    load_with_options(path, &LoadOptions::default()).map(|result| result.font)
+}
+
+/// Like [`load`], but load only the parts of the font requested by `options`,
+/// and report the `<source>` elements that failed to load instead of silently
+/// dropping them: each failure leaves the returned font without the
+/// corresponding master.
+///
+/// Font-level data (names, features, lib, kerning groups) and the glyph list
+/// live in the default source, so it must always load — unless neither
+/// masters nor glyphs are requested, in which case no source UFO is opened at
+/// all and the returned font holds only what the designspace document itself
+/// declares: axes, instances, and bare master records.
+pub fn load_with_options(
+    path: PathBuf,
+    options: &LoadOptions,
+) -> Result<LoadResult, BabelfontError> {
     let ds: DesignSpaceDocument = norad::designspace::DesignSpaceDocument::load(path.clone())?;
     let relative = path.parent();
     let axes: Vec<Axis> = ds
@@ -42,30 +59,62 @@ pub fn load(path: PathBuf) -> Result<Font, BabelfontError> {
         .map(|ax| (ax.name.get_default().unwrap().clone(), ax.tag))
         .collect();
     let default_master = default_master(&ds, &axes).ok_or(BabelfontError::NoDefaultMaster)?;
-    let relative_path_to_default_master = if let Some(r) = relative {
-        r.join(default_master.filename.clone())
+    let mut font = if options.load_masters || options.load_glyphs {
+        let relative_path_to_default_master = if let Some(r) = relative {
+            r.join(default_master.filename.clone())
+        } else {
+            default_master.filename.clone().into()
+        };
+        crate::convertors::ufo::load_with_options(relative_path_to_default_master, options)?
     } else {
-        default_master.filename.clone().into()
+        Font::new()
     };
-    let mut font = crate::convertors::ufo::load(relative_path_to_default_master)?;
-    font.axes = axes;
+    if options.load_axes {
+        font.axes = axes;
+    }
 
     load_instances(&mut font, &axis_name_tag_map, &ds.instances);
-    let res: Vec<(Master, Vec<Vec<Layer>>)> = ds
-        .sources
-        .iter()
-        .filter_map(|source| load_master(&font.glyphs, source, relative, &axis_name_tag_map).ok())
-        .collect();
-    // Drop the default master loaded from the UFO above
+    // Drop the master loaded from the default UFO above, and its layers;
+    // both are rebuilt from the designspace's sources.
     font.masters.clear();
-    // Clear all layers
     for g in font.glyphs.iter_mut() {
         g.layers.clear();
     }
-    for (master, mut layerset) in res {
-        font.masters.push(master);
-        for (g, l) in font.glyphs.iter_mut().zip(layerset.iter_mut()) {
-            g.layers.append(l);
+    let mut failures: Vec<SourceLoadFailure> = Vec::new();
+    if options.load_masters {
+        let load_layers = options.load_layers && options.load_glyphs;
+        let res: Vec<(Master, Vec<Vec<Layer>>)> = ds
+            .sources
+            .iter()
+            .filter_map(|source| {
+                match load_master(
+                    &font.glyphs,
+                    source,
+                    relative,
+                    &axis_name_tag_map,
+                    load_layers,
+                ) {
+                    Ok(master) => Some(master),
+                    Err(e) => {
+                        failures.push(SourceLoadFailure {
+                            filename: source.filename.clone(),
+                            error: e.to_string(),
+                        });
+                        None
+                    }
+                }
+            })
+            .collect();
+        for (master, mut layerset) in res {
+            font.masters.push(master);
+            for (g, l) in font.glyphs.iter_mut().zip(layerset.iter_mut()) {
+                g.layers.append(l);
+            }
+        }
+    } else {
+        // Bare records of what the document declares; no source UFO is opened
+        for source in ds.sources.iter() {
+            font.masters.push(master_record(source, &axis_name_tag_map));
         }
     }
     // Stash DS format
@@ -74,7 +123,10 @@ pub fn load(path: PathBuf) -> Result<Font, BabelfontError> {
         FORMAT_KEY.to_string(),
         serde_json::Value::Number(serde_json::Number::from_f64(ds.format as f64).unwrap()),
     );
-    Ok(font)
+    Ok(LoadResult {
+        font,
+        source_failures: failures,
+    })
 }
 
 pub(crate) fn load_instances(
@@ -142,12 +194,10 @@ pub(crate) fn load_instances(
     }
 }
 
-fn load_master(
-    glyphs: &GlyphList,
-    source: &Source,
-    relative: Option<&std::path::Path>,
-    axis_name_tag_map: &HashMap<String, Tag>,
-) -> Result<(Master, Vec<Vec<Layer>>), BabelfontError> {
+/// Build a [`Master`] from what the designspace document itself declares
+/// about a `<source>` — its name, location, filename and style name —
+/// without opening the source UFO.
+fn master_record(source: &Source, axis_name_tag_map: &HashMap<String, Tag>) -> Master {
     let location = DesignLocation::from(
         source
             .location
@@ -163,7 +213,6 @@ fn load_master(
             })
             .collect::<Vec<_>>(),
     );
-    let required_layer = &source.layer;
     let uuid = Uuid::new_v4().to_string();
 
     let mut master = Master::new(
@@ -182,6 +231,18 @@ fn load_master(
         FILENAME_KEY.to_string(),
         serde_json::Value::String(source.filename.clone()),
     );
+    master
+}
+
+fn load_master(
+    glyphs: &GlyphList,
+    source: &Source,
+    relative: Option<&std::path::Path>,
+    axis_name_tag_map: &HashMap<String, Tag>,
+    load_layers: bool,
+) -> Result<(Master, Vec<Vec<Layer>>), BabelfontError> {
+    let mut master = master_record(source, axis_name_tag_map);
+    let required_layer = &source.layer;
 
     let relative_path_to_master = if let Some(r) = relative {
         r.join(source.filename.clone())
@@ -189,10 +250,19 @@ fn load_master(
         source.filename.clone().into()
     };
 
-    let source_font = norad::Font::load(relative_path_to_master)?;
+    let request = if load_layers {
+        norad::DataRequest::all()
+    } else {
+        // Everything except the glyph layers, so no .glif file is parsed
+        norad::DataRequest::default().layers(false)
+    };
+    let source_font = norad::Font::load_requested_data(relative_path_to_master, request)?;
     let info = &source_font.font_info;
     load_master_info(&mut master, info);
     load_kerning(&mut master, &source_font.kerning);
+    if !load_layers {
+        return Ok((master, vec![]));
+    }
     let ufo_layer = if let Some(source_layer) = required_layer {
         source_font
             .layers
@@ -524,5 +594,218 @@ mod tests {
         let ufo = as_norad(&font, 0).unwrap();
         // Check it has two layers
         assert_eq!(ufo.layers.len(), 2);
+    }
+
+    const PLIST_HEADER: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+"#;
+
+    /// A minimal single-glyph UFO, enough for the designspace loader.
+    fn write_minimal_ufo(dir: &std::path::Path, name: &str) {
+        let ufo = dir.join(name);
+        let glyphs = ufo.join("glyphs");
+        std::fs::create_dir_all(&glyphs).unwrap();
+        std::fs::write(
+            ufo.join("metainfo.plist"),
+            format!("{PLIST_HEADER}<dict><key>creator</key><string>test</string><key>formatVersion</key><integer>3</integer></dict>\n</plist>\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            ufo.join("fontinfo.plist"),
+            format!("{PLIST_HEADER}<dict><key>familyName</key><string>Test</string><key>styleName</key><string>Regular</string><key>unitsPerEm</key><integer>1000</integer><key>ascender</key><integer>800</integer></dict>\n</plist>\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            ufo.join("layercontents.plist"),
+            format!("{PLIST_HEADER}<array><array><string>public.default</string><string>glyphs</string></array></array>\n</plist>\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            glyphs.join("contents.plist"),
+            format!("{PLIST_HEADER}<dict><key>A</key><string>A_.glif</string></dict>\n</plist>\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            glyphs.join("A_.glif"),
+            r#"<?xml version="1.0"?>
+<glyph name="A" format="2"><advance width="500"/><unicode hex="0041"/><outline><contour><point x="0" y="0" type="line"/><point x="400" y="0" type="line"/><point x="400" y="700" type="line"/><point x="0" y="700" type="line"/></contour></outline></glyph>
+"#,
+        )
+        .unwrap();
+    }
+
+    fn write_test_designspace(dir: &std::path::Path, sources: &[&str]) -> PathBuf {
+        let source_elements: String = sources
+            .iter()
+            .enumerate()
+            .map(|(i, filename)| {
+                format!(
+                    r#"<source filename="{filename}"><location><dimension name="Weight" xvalue="{}"/></location></source>"#,
+                    100 + i * 100
+                )
+            })
+            .collect();
+        let ds = dir.join("Test.designspace");
+        std::fs::write(
+            &ds,
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<designspace format="4.1">
+  <axes><axis tag="wght" name="Weight" minimum="100" maximum="900" default="100"/></axes>
+  <sources>{source_elements}</sources>
+</designspace>
+"#
+            ),
+        )
+        .unwrap();
+        ds
+    }
+
+    #[test]
+    fn reports_unloadable_sources() {
+        let tempdir = tempfile::tempdir().unwrap();
+        write_minimal_ufo(tempdir.path(), "Regular.ufo");
+        write_minimal_ufo(tempdir.path(), "Bold.ufo");
+        // Corrupt the non-default source so it cannot load.
+        std::fs::write(
+            tempdir.path().join("Bold.ufo/metainfo.plist"),
+            "not a plist",
+        )
+        .unwrap();
+        let ds_path = write_test_designspace(tempdir.path(), &["Regular.ufo", "Bold.ufo"]);
+
+        let result = load_with_options(ds_path.clone(), &LoadOptions::default()).unwrap();
+        assert_eq!(result.font.masters.len(), 1);
+        assert_eq!(result.source_failures.len(), 1);
+        assert_eq!(result.source_failures[0].filename, "Bold.ufo");
+        assert!(!result.source_failures[0].error.is_empty());
+
+        // `load` keeps its existing behavior: the loadable master, no error.
+        let font = load(ds_path).unwrap();
+        assert_eq!(font.masters.len(), 1);
+    }
+
+    #[test]
+    fn report_is_empty_when_all_sources_load() {
+        let tempdir = tempfile::tempdir().unwrap();
+        write_minimal_ufo(tempdir.path(), "Regular.ufo");
+        write_minimal_ufo(tempdir.path(), "Bold.ufo");
+        let ds_path = write_test_designspace(tempdir.path(), &["Regular.ufo", "Bold.ufo"]);
+
+        let result = load_with_options(ds_path, &LoadOptions::default()).unwrap();
+        assert_eq!(result.font.masters.len(), 2);
+        assert!(result.source_failures.is_empty());
+    }
+
+    #[test]
+    fn skip_layers_keeps_masters_and_glyph_stubs() {
+        let tempdir = tempfile::tempdir().unwrap();
+        write_minimal_ufo(tempdir.path(), "Regular.ufo");
+        write_minimal_ufo(tempdir.path(), "Bold.ufo");
+        let ds_path = write_test_designspace(tempdir.path(), &["Regular.ufo", "Bold.ufo"]);
+
+        let result = load_with_options(
+            ds_path,
+            &LoadOptions {
+                load_layers: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(result.source_failures.is_empty());
+        let font = result.font;
+        assert_eq!(font.masters.len(), 2);
+        // Master content is loaded from the source UFOs
+        assert!(!font.masters[0].metrics.is_empty());
+        // Font-level data is loaded from the default source
+        assert_eq!(
+            font.names.family_name.get_default(),
+            Some(&"Test".to_string())
+        );
+        // The glyph list holds layer-less stubs
+        let glyph = font.glyphs.get("A").unwrap();
+        assert!(glyph.layers.is_empty());
+    }
+
+    #[test]
+    fn skip_glyphs_keeps_font_and_master_data() {
+        let tempdir = tempfile::tempdir().unwrap();
+        write_minimal_ufo(tempdir.path(), "Regular.ufo");
+        write_minimal_ufo(tempdir.path(), "Bold.ufo");
+        let ds_path = write_test_designspace(tempdir.path(), &["Regular.ufo", "Bold.ufo"]);
+
+        let result = load_with_options(
+            ds_path,
+            &LoadOptions {
+                load_glyphs: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let font = result.font;
+        assert!(font.glyphs.is_empty());
+        assert_eq!(font.masters.len(), 2);
+        assert_eq!(
+            font.names.family_name.get_default(),
+            Some(&"Test".to_string())
+        );
+    }
+
+    #[test]
+    fn skip_masters_does_not_open_sources() {
+        let tempdir = tempfile::tempdir().unwrap();
+        // The source UFOs are never written: a partial parse of the document
+        // alone must not try to open them.
+        let ds_path = write_test_designspace(tempdir.path(), &["Regular.ufo", "Bold.ufo"]);
+
+        let result = load_with_options(
+            ds_path,
+            &LoadOptions {
+                load_masters: false,
+                load_glyphs: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(result.source_failures.is_empty());
+        let font = result.font;
+        assert_eq!(font.axes.len(), 1);
+        assert!(font.glyphs.is_empty());
+        // Bare master records, straight from the document
+        assert_eq!(font.masters.len(), 2);
+        assert_eq!(
+            font.masters[1]
+                .location
+                .get(Tag::new(b"wght"))
+                .map(|x| x.to_f64()),
+            Some(200.0)
+        );
+        assert_eq!(
+            font.masters[1]
+                .format_specific
+                .get(FILENAME_KEY)
+                .and_then(|v| v.as_str()),
+            Some("Bold.ufo")
+        );
+        assert!(font.masters[1].metrics.is_empty());
+    }
+
+    #[test]
+    fn skip_axes() {
+        let tempdir = tempfile::tempdir().unwrap();
+        write_minimal_ufo(tempdir.path(), "Regular.ufo");
+        let ds_path = write_test_designspace(tempdir.path(), &["Regular.ufo"]);
+
+        let result = load_with_options(
+            ds_path,
+            &LoadOptions {
+                load_axes: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(result.font.axes.is_empty());
+        assert_eq!(result.font.masters.len(), 1);
     }
 }

--- a/babelfont/src/convertors/glyphs3.rs
+++ b/babelfont/src/convertors/glyphs3.rs
@@ -3,7 +3,7 @@ use crate::{
     glyph::{self, glyphs::glyph_to_glyphs},
     i18ndictionary::I18NDictionary,
     names::Names,
-    Axis, BabelfontError, CustomOTValues, Font, GlyphList, Master, Tag,
+    Axis, BabelfontError, CustomOTValues, Font, GlyphList, LoadOptions, Master, Tag,
 };
 use fontdrasil::coords::{DesignCoord, DesignLocation, UserCoord};
 use glyphslib::glyphs3::{self, Property};
@@ -124,21 +124,39 @@ pub(crate) fn copy_user_data(
 
 /// Load a Glyphs font from a file path
 pub fn load(path: PathBuf) -> Result<Font, BabelfontError> {
+    load_with_options(path, &LoadOptions::default())
+}
+
+/// Like [`load`], but convert only the parts of the font requested by
+/// `options`. The file still has to be parsed in full; the savings come from
+/// skipping the conversion of parts that were not requested.
+pub fn load_with_options(path: PathBuf, options: &LoadOptions) -> Result<Font, BabelfontError> {
     if path.extension().and_then(|x| x.to_str()) == Some("glyphspackage") {
         return _load(
             &glyphslib::Font::load(&path).map_err(|x| BabelfontError::PlistParse(x.to_string()))?,
             path,
+            options,
         );
     }
     let s = fs::read_to_string(&path)?;
-    load_str(&s, path.clone())
+    load_str_with_options(&s, path.clone(), options)
 }
 
 /// Load a Glyphs font from a string
 pub fn load_str(s: &str, path: PathBuf) -> Result<Font, BabelfontError> {
+    load_str_with_options(s, path, &LoadOptions::default())
+}
+
+/// Like [`load_str`], but convert only the parts of the font requested by
+/// `options`.
+pub fn load_str_with_options(
+    s: &str,
+    path: PathBuf,
+    options: &LoadOptions,
+) -> Result<Font, BabelfontError> {
     let glyphs_font =
         glyphslib::Font::load_str(s).map_err(|x| BabelfontError::PlistParse(x.to_string()))?;
-    _load(&glyphs_font, path)
+    _load(&glyphs_font, path, options)
 }
 
 /// Load a Glyphs package font from in-memory package entries
@@ -146,12 +164,26 @@ pub fn load_package_entries(
     path: PathBuf,
     entries: &HashMap<String, String>,
 ) -> Result<Font, BabelfontError> {
-    let glyphs_font = glyphslib::Font::load_package_entries(entries)
-        .map_err(|x| BabelfontError::PlistParse(x.to_string()))?;
-    _load(&glyphs_font, path)
+    load_package_entries_with_options(path, entries, &LoadOptions::default())
 }
 
-fn _load(glyphs_font: &glyphslib::Font, path: PathBuf) -> Result<Font, BabelfontError> {
+/// Like [`load_package_entries`], but convert only the parts of the font
+/// requested by `options`.
+pub fn load_package_entries_with_options(
+    path: PathBuf,
+    entries: &HashMap<String, String>,
+    options: &LoadOptions,
+) -> Result<Font, BabelfontError> {
+    let glyphs_font = glyphslib::Font::load_package_entries(entries)
+        .map_err(|x| BabelfontError::PlistParse(x.to_string()))?;
+    _load(&glyphs_font, path, options)
+}
+
+fn _load(
+    glyphs_font: &glyphslib::Font,
+    path: PathBuf,
+    options: &LoadOptions,
+) -> Result<Font, BabelfontError> {
     let mut font = Font::new();
     let mut upgraded = glyphs_font.clone();
     let glyphs_font = if glyphs_font.as_glyphs2().is_some() {
@@ -221,13 +253,15 @@ fn _load(glyphs_font: &glyphslib::Font, path: PathBuf) -> Result<Font, Babelfont
         .map(|master| load_master(master, glyphs_font, &font))
         .collect();
     // Glyphs
-    font.glyphs = GlyphList(
-        glyphs_font
-            .glyphs
-            .iter()
-            .map(|g| glyph::glyphs::from_glyphs(g, &axes_order))
-            .collect::<Result<Vec<_>, BabelfontError>>()?,
-    );
+    if options.load_glyphs {
+        font.glyphs = GlyphList(
+            glyphs_font
+                .glyphs
+                .iter()
+                .map(|g| glyph::glyphs::from_glyphs(g, &axes_order, options.load_layers))
+                .collect::<Result<Vec<_>, BabelfontError>>()?,
+        );
+    }
     // Instances
     font.instances = glyphs_font
         .instances
@@ -312,6 +346,10 @@ fn _load(glyphs_font: &glyphslib::Font, path: PathBuf) -> Result<Font, Babelfont
 
     // Bake in Glyphs data ??? When is best to do this?
     // GlyphsData.apply(&mut font)?;
+
+    // Masters and axes are always converted, because interpreting the axes
+    // needs the master locations; drop whatever was not requested.
+    options.filter_loaded_font(&mut font);
 
     Ok(font)
 }
@@ -1481,5 +1519,64 @@ mod tests {
             DesignLocation::from(vec![(Tag::new(b"wght"), DesignCoord::new(400.0))])
         );
         assert_eq!(font.axes[0].min, Some(UserCoord::new(400.0)));
+    }
+
+    #[test]
+    fn load_with_options_partial() {
+        let path = PathBuf::from("resources/RadioCanadaDisplay.glyphs");
+        let full = load(path.clone()).unwrap();
+
+        // Skipping layers keeps glyph-level data: names, codepoints, and the
+        // kerning-group membership Glyphs stores on its glyphs
+        let no_layers = load_with_options(
+            path.clone(),
+            &LoadOptions {
+                load_layers: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(full.glyphs.len(), no_layers.glyphs.len());
+        assert!(no_layers.glyphs.iter().all(|g| g.layers.is_empty()));
+        assert_eq!(
+            full.glyphs.get("A").unwrap().codepoints,
+            no_layers.glyphs.get("A").unwrap().codepoints
+        );
+        assert!(!full.first_kern_groups.is_empty());
+        assert_eq!(full.first_kern_groups, no_layers.first_kern_groups);
+
+        // Skipping glyphs keeps masters and axes
+        let no_glyphs = load_with_options(
+            path.clone(),
+            &LoadOptions {
+                load_glyphs: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(no_glyphs.glyphs.is_empty());
+        assert_eq!(full.masters.len(), no_glyphs.masters.len());
+
+        // Axis interpretation needs the master locations, so it still works
+        // when masters are reduced to bare records
+        let bare = load_with_options(
+            path,
+            &LoadOptions {
+                load_masters: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let axis_ranges = |font: &Font| {
+            font.axes
+                .iter()
+                .map(|a| (a.tag, a.min, a.max, a.default))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(axis_ranges(&full), axis_ranges(&bare));
+        assert_eq!(full.masters.len(), bare.masters.len());
+        assert!(bare.masters[0].metrics.is_empty());
+        // Layers belong to masters, so they are dropped too
+        assert!(bare.glyphs.iter().all(|g| g.layers.is_empty()));
     }
 }

--- a/babelfont/src/convertors/ufo.rs
+++ b/babelfont/src/convertors/ufo.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::decomposition::DecomposedAffine, features::Features, glyph::GlyphCategory,
-    BabelfontError, Component, Font, Glyph, Layer, LayerType, Master, MetricType, Node, Path,
-    Shape,
+    BabelfontError, Component, Font, Glyph, Layer, LayerType, LoadOptions, Master, MetricType,
+    Node, Path, Shape,
 };
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use fontdrasil::{coords::Location, types::Tag};
@@ -69,11 +69,36 @@ pub(crate) fn stat(path: &std::path::Path) -> Option<DateTime<chrono::Local>> {
 
 /// Load a UFO font from a file path
 pub fn load<T: AsRef<std::path::Path>>(path: T) -> Result<Font, BabelfontError> {
+    load_with_options(path, &LoadOptions::default())
+}
+
+/// Like [`load`], but load only the parts of the font requested by `options`.
+///
+/// Glyph layers can only be attached to a loaded master, so layers are
+/// skipped — and no `.glif` file is parsed — unless `load_masters`,
+/// `load_glyphs` and `load_layers` are all `true`. Without layers, glyphs
+/// are stubs named after the default layer's `contents.plist` entries.
+pub fn load_with_options<T: AsRef<std::path::Path>>(
+    path: T,
+    options: &LoadOptions,
+) -> Result<Font, BabelfontError> {
     let mut font = Font::new();
     let created_time: Option<DateTime<Utc>> = stat(path.as_ref()).map(DateTime::<Utc>::from);
-    let ufo = norad::Font::load(&path)?;
+    let load_layers = options.load_layers && options.load_masters && options.load_glyphs;
+    let request = if load_layers {
+        norad::DataRequest::all()
+    } else {
+        // Everything except the glyph layers, so no .glif file is parsed
+        norad::DataRequest::default().layers(false)
+    };
+    let ufo = norad::Font::load_requested_data(&path, request)?;
     font.format_specific = stash_lib(Some(&ufo.lib));
-    load_glyphs(&mut font, &ufo);
+    if load_layers {
+        load_glyphs(&mut font, &ufo);
+    } else if options.load_glyphs {
+        let names = default_layer_glyph_names(path.as_ref())?;
+        load_glyph_stubs(&mut font, &ufo, names);
+    }
     let info = &ufo.font_info;
     load_font_info(&mut font, info, created_time);
     let mut master = Master::new(
@@ -83,8 +108,10 @@ pub fn load<T: AsRef<std::path::Path>>(path: T) -> Result<Font, BabelfontError> 
         uuid::Uuid::new_v4().to_string(),
         Location::new(),
     );
-    load_master_info(&mut master, info);
-    load_kerning(&mut master, &ufo.kerning);
+    if options.load_masters {
+        load_master_info(&mut master, info);
+        load_kerning(&mut master, &ufo.kerning);
+    }
     (font.first_kern_groups, font.second_kern_groups) = load_kern_groups(&ufo.groups);
 
     for layer in ufo.iter_layers() {
@@ -949,6 +976,38 @@ pub(crate) fn load_kern_groups(
 }
 
 pub(crate) fn load_glyphs(font: &mut Font, ufo: &norad::Font) {
+    let names = ufo.iter_names().map(|x| x.to_string()).collect();
+    load_glyphs_from_names(font, ufo, names, true);
+}
+
+/// Populate the font's glyph list with layer-less stubs for the given names.
+///
+/// Glyph-level data from the UFO lib (categories, production names, export
+/// flags) is applied, but codepoints — which live in the unparsed `.glif`
+/// files — are not available.
+pub(crate) fn load_glyph_stubs(font: &mut Font, ufo: &norad::Font, names: Vec<String>) {
+    load_glyphs_from_names(font, ufo, names, false);
+}
+
+/// Read the glyph names of the default layer without parsing any `.glif`
+/// file. The UFO specification requires the default layer to be stored in
+/// the `glyphs` directory.
+fn default_layer_glyph_names(path: &std::path::Path) -> Result<Vec<String>, BabelfontError> {
+    let contents = path.join("glyphs").join("contents.plist");
+    let value = plist::Value::from_file(&contents)
+        .map_err(|e| BabelfontError::UfoLoad(format!("{}: {}", contents.display(), e)))?;
+    let dict = value.as_dictionary().ok_or_else(|| {
+        BabelfontError::UfoLoad(format!("{}: expected a dictionary", contents.display()))
+    })?;
+    Ok(dict.keys().cloned().collect())
+}
+
+fn load_glyphs_from_names(
+    font: &mut Font,
+    ufo: &norad::Font,
+    mut ufo_names: Vec<String>,
+    require_glyph_data: bool,
+) {
     let categories = ufo.lib.get(KEY_CATEGORIES).and_then(|x| x.as_dictionary());
     let psnames = ufo.lib.get(KEY_PSNAMES).and_then(|x| x.as_dictionary());
     let skipped: HashSet<String> = ufo
@@ -971,7 +1030,6 @@ pub(crate) fn load_glyphs(font: &mut Font, ufo: &norad::Font) {
         .map(|x| x.to_string())
         .collect();
     let mut order: Vec<String> = vec![];
-    let mut ufo_names: Vec<String> = ufo.iter_names().map(|x| x.to_string()).collect();
     // We don't do .notdef reordering. We should move it to glyph 0 on TTF build, not at source level.
     // if ufo_names.contains(&".notdef".to_string()) {
     //     order.push(".notdef".to_string());
@@ -987,33 +1045,37 @@ pub(crate) fn load_glyphs(font: &mut Font, ufo: &norad::Font) {
     order.append(&mut ufo_names);
 
     for glyphname in order {
-        if let Some(glyph) = ufo.get_glyph(glyphname.as_str()) {
-            let cat = if let Some(cats) = categories {
-                match cats.get(&glyphname).and_then(|x| x.as_string()) {
-                    Some("base") => GlyphCategory::Base,
-                    Some("mark") => GlyphCategory::Mark,
-                    Some("ligature") => GlyphCategory::Ligature,
-                    _ => GlyphCategory::Base,
-                }
-            } else {
-                GlyphCategory::Base
-            };
-            let production_name = psnames
-                .and_then(|x| x.get(&glyphname))
-                .and_then(|x| x.as_string())
-                .map(|x| x.into());
-            font.glyphs.push(Glyph {
-                name: SmolStr::from(glyphname.as_str()),
-                category: cat,
-                production_name,
-                codepoints: glyph.codepoints.iter().map(|x| x as u32).collect(),
-                layers: vec![],
-                exported: !skipped.contains(&glyphname),
-                direction: None,
-                format_specific: Default::default(),
-                component_axes: Default::default(),
-            })
+        let norad_glyph = ufo.get_glyph(glyphname.as_str());
+        if require_glyph_data && norad_glyph.is_none() {
+            continue;
         }
+        let cat = if let Some(cats) = categories {
+            match cats.get(&glyphname).and_then(|x| x.as_string()) {
+                Some("base") => GlyphCategory::Base,
+                Some("mark") => GlyphCategory::Mark,
+                Some("ligature") => GlyphCategory::Ligature,
+                _ => GlyphCategory::Base,
+            }
+        } else {
+            GlyphCategory::Base
+        };
+        let production_name = psnames
+            .and_then(|x| x.get(&glyphname))
+            .and_then(|x| x.as_string())
+            .map(|x| x.into());
+        font.glyphs.push(Glyph {
+            name: SmolStr::from(glyphname.as_str()),
+            category: cat,
+            production_name,
+            codepoints: norad_glyph
+                .map(|glyph| glyph.codepoints.iter().map(|x| x as u32).collect())
+                .unwrap_or_default(),
+            layers: vec![],
+            exported: !skipped.contains(&glyphname),
+            direction: None,
+            format_specific: Default::default(),
+            component_axes: Default::default(),
+        })
     }
     add_uvs_sequences(font, ufo);
 }
@@ -1051,6 +1113,53 @@ pub(crate) mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+
+    #[test]
+    fn load_without_layers_stubs_glyphs() {
+        let full = load("resources/IbarraRealNova-Regular.ufo").unwrap();
+        let partial = load_with_options(
+            "resources/IbarraRealNova-Regular.ufo",
+            &LoadOptions {
+                load_layers: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // Same glyph inventory, but as layer-less stubs
+        let names = |font: &Font| -> std::collections::BTreeSet<SmolStr> {
+            font.glyphs.iter().map(|g| g.name.clone()).collect()
+        };
+        assert_eq!(names(&full), names(&partial));
+        assert!(partial.glyphs.iter().all(|g| g.layers.is_empty()));
+        // Master and font-level data are unaffected
+        assert_eq!(
+            full.masters[0].kerning.len(),
+            partial.masters[0].kerning.len()
+        );
+        assert!(!partial.masters[0].kerning.is_empty());
+        assert_eq!(full.masters[0].metrics, partial.masters[0].metrics);
+        assert_eq!(
+            full.names.family_name.get_default(),
+            partial.names.family_name.get_default()
+        );
+        assert_eq!(full.first_kern_groups, partial.first_kern_groups);
+    }
+
+    #[test]
+    fn load_without_glyphs() {
+        let font = load_with_options(
+            "resources/IbarraRealNova-Regular.ufo",
+            &LoadOptions {
+                load_glyphs: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(font.glyphs.is_empty());
+        assert_eq!(font.masters.len(), 1);
+        assert!(!font.masters[0].kerning.is_empty());
+        assert!(font.names.family_name.get_default().is_some());
+    }
 
     pub(crate) fn ufo_semantic_test(ufo1: &norad::Font, ufo2: &norad::Font, do_metadata: bool) {
         assert_eq!(

--- a/babelfont/src/glyph.rs
+++ b/babelfont/src/glyph.rs
@@ -182,7 +182,11 @@ pub(crate) mod glyphs {
     use glyphslib::glyphs3::Glyph as G3Glyph;
     use indexmap::IndexMap;
 
-    pub(crate) fn from_glyphs(val: &G3Glyph, axes_order: &[Tag]) -> Result<Glyph, BabelfontError> {
+    pub(crate) fn from_glyphs(
+        val: &G3Glyph,
+        axes_order: &[Tag],
+        load_layers: bool,
+    ) -> Result<Glyph, BabelfontError> {
         let mut format_specific = FormatSpecific::default();
         format_specific.insert_json_non_null("case", &val.case);
         format_specific.insert_json_non_null("color", &val.color);
@@ -229,20 +233,22 @@ pub(crate) mod glyphs {
             .collect();
         // Now pre-chew them for easy layer generation
         let sc_axes = glyph_specific_axes(&component_axes);
-        for layer in &val.layers {
-            let mut bf_layer = layer_from_glyphs(layer, axes_order, &sc_axes)?;
-            if let Some(bg_layer) = &layer.background {
-                let mut background = layer_from_glyphs(bg_layer.deref(), axes_order, &sc_axes)?;
-                background.is_background = true;
-                if background.id.is_none() || background.id == Some("".to_string()) {
-                    background.id =
-                        Some(format!("{}.bg", bf_layer.id.as_deref().unwrap_or("layer")));
+        if load_layers {
+            for layer in &val.layers {
+                let mut bf_layer = layer_from_glyphs(layer, axes_order, &sc_axes)?;
+                if let Some(bg_layer) = &layer.background {
+                    let mut background = layer_from_glyphs(bg_layer.deref(), axes_order, &sc_axes)?;
+                    background.is_background = true;
+                    if background.id.is_none() || background.id == Some("".to_string()) {
+                        background.id =
+                            Some(format!("{}.bg", bf_layer.id.as_deref().unwrap_or("layer")));
+                    }
+                    bf_layer.background_layer_id = background.id.clone();
+                    layers.push(bf_layer);
+                    layers.push(background);
+                } else {
+                    layers.push(bf_layer);
                 }
-                bf_layer.background_layer_id = background.id.clone();
-                layers.push(bf_layer);
-                layers.push(background);
-            } else {
-                layers.push(bf_layer);
             }
         }
         let sc_locations = layers

--- a/babelfont/src/lib.rs
+++ b/babelfont/src/lib.rs
@@ -50,6 +50,35 @@
 //! # }
 //! ```
 //!
+//! ## Partial loading
+//!
+//! [`load_with_options`] gives finer control over how much of a font is
+//! loaded. Every [`LoadOptions`] flag defaults to `true`; switching flags off
+//! skips the corresponding ingestion work. For example, skipping glyph layers
+//! avoids parsing any `.glif` file in a designspace's sources, which can turn
+//! loading a large multi-master font from seconds into milliseconds while
+//! still providing names, axes, masters, metrics, kerning, features, and a
+//! stub glyph list:
+//!
+//! ```no_run
+//! # use babelfont::{load_with_options, LoadOptions, BabelfontError};
+//! # fn main() -> Result<(), BabelfontError> {
+//! let result = load_with_options(
+//!     "MyFont.designspace",
+//!     &LoadOptions {
+//!         load_layers: false,
+//!         ..Default::default()
+//!     },
+//! )?;
+//! println!("Loaded {} glyph stubs", result.font.glyphs.len());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`load_with_options`] also reports designspace sources that failed to
+//! load, instead of silently dropping them as [`load`] does (see
+//! [`LoadResult::source_failures`]).
+//!
 //! ## Font Filters
 //!
 //! Babelfont includes a set of filters for manipulating fonts. Filters implement the
@@ -153,6 +182,7 @@ mod instance;
 mod interpolate;
 mod layer;
 mod layout;
+mod load;
 mod master;
 mod metrics;
 mod names;
@@ -172,6 +202,7 @@ pub use crate::{
     instance::Instance,
     layer::{Layer, LayerType},
     layout::closure::close_layout,
+    load::{LoadOptions, LoadResult, SourceLoadFailure},
     master::Master,
     metrics::MetricType,
     names::Names,
@@ -202,36 +233,69 @@ pub use write_fonts::read::tables::name::NameId;
 /// - "glyphs": Glyphs files
 /// - "fontlab": FontLab VFJ files
 pub fn load(filename: impl Into<PathBuf>) -> Result<Font, BabelfontError> {
+    load_with_options(filename, &LoadOptions::default()).map(|result| result.font)
+}
+
+/// Like [`load`], but load only the parts of the font requested by `options`,
+/// and report sources that failed to load rather than silently dropping them.
+///
+/// See [`LoadOptions`] for what can be skipped and [`LoadResult`] for what is
+/// returned. The UFO, designspace, and Glyphs convertors skip the ingestion
+/// work for parts that are not requested; the remaining formats are loaded in
+/// full and then filtered, so the result has the same shape for every format.
+pub fn load_with_options(
+    filename: impl Into<PathBuf>,
+    options: &LoadOptions,
+) -> Result<LoadResult, BabelfontError> {
     let pb = filename.into();
     let pb_clone = pb.clone();
 
-    let mut font: Font = match pb.extension() {
+    let mut result: LoadResult = match pb.extension() {
         Some(ext) if ext == "babelfont" => {
             let buffered = std::io::BufReader::new(std::fs::File::open(&pb)?);
-            Ok(serde_json::from_reader(buffered)?)
+            let font: Font = serde_json::from_reader(buffered)?;
+            filtered(Ok(font), options)
         }
         #[cfg(feature = "ufo")]
-        Some(ext) if ext == "designspace" => crate::convertors::designspace::load(pb),
+        Some(ext) if ext == "designspace" => {
+            crate::convertors::designspace::load_with_options(pb, options)
+        }
         #[cfg(feature = "fontra")]
-        Some(ext) if ext == "fontra" => crate::convertors::fontra::load(pb),
+        Some(ext) if ext == "fontra" => filtered(crate::convertors::fontra::load(pb), options),
         #[cfg(feature = "fontlab")]
-        Some(ext) if ext == "vfj" => crate::convertors::fontlab::load(pb),
+        Some(ext) if ext == "vfj" => filtered(crate::convertors::fontlab::load(pb), options),
         #[cfg(feature = "ufo")]
-        Some(ext) if ext == "ufo" => crate::convertors::ufo::load(pb),
+        Some(ext) if ext == "ufo" => {
+            crate::convertors::ufo::load_with_options(pb, options).map(LoadResult::from)
+        }
         #[cfg(feature = "fontforge")]
-        Some(ext) if ext == "sfd" || ext == "sfdir" => crate::convertors::fontforge::load(pb),
+        Some(ext) if ext == "sfd" || ext == "sfdir" => {
+            filtered(crate::convertors::fontforge::load(pb), options)
+        }
         #[cfg(feature = "vfb")]
-        Some(ext) if ext == "vfb" => crate::convertors::vfb::load(pb),
+        Some(ext) if ext == "vfb" => filtered(crate::convertors::vfb::load(pb), options),
         #[cfg(feature = "robocjk")]
-        Some(ext) if ext == "rcjk" => crate::convertors::robocjk::load(pb),
+        Some(ext) if ext == "rcjk" => filtered(crate::convertors::robocjk::load(pb), options),
         #[cfg(feature = "glyphs")]
         Some(ext) if ext == "glyphs" || ext == "glyphspackage" => {
-            crate::convertors::glyphs3::load(pb)
+            crate::convertors::glyphs3::load_with_options(pb, options).map(LoadResult::from)
         }
         #[cfg(feature = "ttf")]
-        Some(ext) if ext == "ttf" => crate::convertors::ttf::load(pb),
+        Some(ext) if ext == "ttf" => filtered(crate::convertors::ttf::load(pb), options),
         _ => Err(BabelfontError::UnknownFileType { path: pb }),
     }?;
-    font.source = Some(pb_clone);
-    Ok(font)
+    result.font.source = Some(pb_clone);
+    Ok(result)
+}
+
+/// Load in full, then drop the parts `options` excludes — for formats whose
+/// convertors cannot skip the work at load time.
+fn filtered(
+    font: Result<Font, BabelfontError>,
+    options: &LoadOptions,
+) -> Result<LoadResult, BabelfontError> {
+    font.map(|mut font| {
+        options.filter_loaded_font(&mut font);
+        LoadResult::from(font)
+    })
 }

--- a/babelfont/src/load.rs
+++ b/babelfont/src/load.rs
@@ -1,0 +1,145 @@
+use crate::{Font, Master};
+
+/// Options controlling how much of a font [`crate::load_with_options`] loads.
+///
+/// Every flag defaults to `true`, which loads the whole font and matches
+/// [`crate::load`]. Switching flags off skips the corresponding ingestion
+/// work, which can make loading large fonts substantially faster — most
+/// notably for designspace/UFO fonts, where skipping glyph layers avoids
+/// parsing any `.glif` file, and skipping masters avoids opening the source
+/// UFOs at all. Single-file formats still have to be parsed in full, but
+/// skip the conversion of the parts that were not requested.
+///
+/// ```
+/// use babelfont::LoadOptions;
+///
+/// let metadata_only = LoadOptions {
+///     load_layers: false,
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct LoadOptions {
+    /// Populate [`Font::axes`](crate::Font). When `false`, the returned font
+    /// has no axes.
+    pub load_axes: bool,
+    /// Load the content of each master: metrics, kerning, guides, and custom
+    /// data. When `false`, the font's masters are bare records of what the
+    /// file declares — name, id, and location (plus, for designspace sources,
+    /// the filename and style name) — and formats that store masters in
+    /// separate files do not open those files at all. Implies
+    /// `load_layers: false`, since layers belong to masters.
+    pub load_masters: bool,
+    /// Populate [`Font::glyphs`](crate::Font). When `false`, the returned
+    /// font has no glyphs. (Glyphs-format fonts store kerning-group
+    /// membership on their glyphs, so kerning groups are lost too; use
+    /// `load_layers: false` instead if you need them.)
+    pub load_glyphs: bool,
+    /// Load glyph layers (outlines, anchors, and other per-layer data). When
+    /// `false`, glyphs are stubs without layers: for UFO and designspace
+    /// fonts their names are read from the default layer's `contents.plist`,
+    /// so codepoints — which live in the unparsed `.glif` files — are not
+    /// available; Glyphs-format stubs keep codepoints and the rest of their
+    /// glyph-level data. Only effective when `load_masters` and `load_glyphs`
+    /// are `true`.
+    pub load_layers: bool,
+}
+
+impl Default for LoadOptions {
+    fn default() -> Self {
+        LoadOptions {
+            load_axes: true,
+            load_masters: true,
+            load_glyphs: true,
+            load_layers: true,
+        }
+    }
+}
+
+impl LoadOptions {
+    /// Drop the parts of a fully-loaded font that these options exclude.
+    ///
+    /// Used for formats whose convertors cannot skip the work at load time,
+    /// so that the result has the same shape for every format.
+    pub(crate) fn filter_loaded_font(&self, font: &mut Font) {
+        if !self.load_axes {
+            font.axes.clear();
+        }
+        if !self.load_glyphs {
+            font.glyphs.clear();
+        }
+        if !self.load_masters {
+            font.masters = font
+                .masters
+                .iter()
+                .map(|m| Master::new(m.name.clone(), m.id.clone(), m.location.clone()))
+                .collect();
+        }
+        if !(self.load_masters && self.load_layers) {
+            for g in font.glyphs.iter_mut() {
+                g.layers.clear();
+            }
+        }
+    }
+}
+
+/// A constituent of a font that failed to load, reported by
+/// [`crate::load_with_options`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SourceLoadFailure {
+    /// The name of the source as the font declares it (for a designspace,
+    /// the `filename` attribute of the `<source>` element).
+    pub filename: String,
+    /// The error that prevented the source from loading.
+    pub error: String,
+}
+
+/// The result of [`crate::load_with_options`].
+#[derive(Debug)]
+pub struct LoadResult {
+    /// The loaded font.
+    pub font: Font,
+    /// Sources that failed to load and were skipped: each failure leaves the
+    /// returned font without the corresponding master's content. Always empty
+    /// for single-file formats, which either load or fail outright.
+    pub source_failures: Vec<SourceLoadFailure>,
+}
+
+impl From<Font> for LoadResult {
+    /// Wrap a font that loaded without any source failures.
+    fn from(font: Font) -> Self {
+        LoadResult {
+            font,
+            source_failures: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use crate::LoadOptions;
+
+    #[test]
+    fn options_filter_formats_without_native_support() {
+        let full = crate::load("resources/RadioCanadaDisplay.babelfont").unwrap();
+        let result = crate::load_with_options(
+            "resources/RadioCanadaDisplay.babelfont",
+            &LoadOptions {
+                load_glyphs: false,
+                load_masters: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let font = result.font;
+        assert!(result.source_failures.is_empty());
+        assert!(font.glyphs.is_empty());
+        assert_eq!(font.masters.len(), full.masters.len());
+        // Bare master records: identity and location, but no content
+        assert_eq!(font.masters[0].location, full.masters[0].location);
+        assert!(font.masters[0].kerning.is_empty());
+        assert!(font.masters[0].metrics.is_empty());
+    }
+}


### PR DESCRIPTION
Reworked to implement the `load_with_options` API you sketched in #33, folding in the source-failure reporting this PR originally proposed.

## API

```rust
pub struct LoadOptions {
    pub load_axes: bool,     // all default to true
    pub load_masters: bool,
    pub load_glyphs: bool,
    pub load_layers: bool,
}

pub struct LoadResult {
    pub font: Font,
    pub source_failures: Vec<SourceLoadFailure>, // { filename, error }
}

pub fn load_with_options(filename: impl Into<PathBuf>, options: &LoadOptions)
    -> Result<LoadResult, BabelfontError>;
```

`load()` is now a thin façade over `load_with_options` and behaves exactly as before (including silently skipping unloadable designspace sources).

## Semantics

- `load_axes: false` — no axes on the returned font.
- `load_masters: false` — masters are bare records of what the file declares (name, id, location; for designspace sources also filename/style name), and designspace source UFOs are not opened at all. Combined with `load_glyphs: false` this parses just the designspace XML: your "axes/masters/instances without the sources" case. Implies no layers, since layers belong to masters.
- `load_glyphs: false` — no glyphs.
- `load_layers: false` — glyphs are layer-less stubs. For UFO/designspace the names come from the default layer's `contents.plist`, so **no `.glif` file is parsed anywhere** (norad `DataRequest::default().layers(false)`); lib-derived categories, production names and export flags are kept, codepoints aren't (they live in the glifs). Glyphs-format stubs keep codepoints and kern-group membership.

## Implementation notes

- UFO, designspace, and Glyphs convertors skip the ingestion work natively. The remaining formats (fontra, vfj, sfd, rcjk, vfb, ttf, .babelfont) load fully and are filtered afterwards, so every format honours the options with the same result shape; native skipping can be added per-format later without an API change.
- Designspace: the default source is only opened when masters or glyphs are requested. Sources that fail to load land in `source_failures` instead of vanishing in the `filter_map`; each failure leaves the font without that master.
- Glyphs format: masters and axes are always converted internally (axis min/max/default interpretation needs the master locations) and the unrequested parts are dropped at the end, so `load_masters: false` still returns correctly-interpreted axes.

## Numbers

Measured against googlefonts/roboto-serif's `RobotoSerif.designspace` (81 sources, release build) — the case that motivated #33:

| options | time | result |
|---|---|---|
| full load | 5.0 s | 77 masters, 1264 glyphs with layers |
| `load_layers: false` | 460 ms | 77 masters with metrics+kerning, 1264 glyph stubs |
| `load_masters/glyphs: false` | 0.6 ms | 81 bare master records, axes, instances |

(The remaining 4 of the 81 sources fail on an unrelated norad fontinfo issue — linebender/norad#414 — and are now visible in `source_failures` rather than silently missing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)