### PR TITLE
Fix node format-specific deserialization with whitespace

### DIFF
--- a/babelfont/src/serde_helpers.rs
+++ b/babelfont/src/serde_helpers.rs
@@ -165,15 +165,12 @@ where
 {
     let s: String = serde::Deserialize::deserialize(deserializer)?;
     let mut nodes = Vec::new();
-    let mut tokens = s.split_whitespace();
-    while let Some(token) = tokens.next() {
-        let x_str = token;
-        let y_str = tokens
-            .next()
+    let mut remaining = s.as_str();
+    while let Some((x_str, next)) = take_node_token(remaining) {
+        let (y_str, next) = take_node_token(next)
             .ok_or_else(|| serde::de::Error::custom("Expected y coordinate"))?;
-        let type_str = tokens
-            .next()
-            .ok_or_else(|| serde::de::Error::custom("Expected node type"))?;
+        let (type_str, next) =
+            take_node_token(next).ok_or_else(|| serde::de::Error::custom("Expected node type"))?;
         let x: f64 = x_str
             .parse()
             .map_err(|_| serde::de::Error::custom(format!("Invalid x coordinate: {}", x_str)))?;
@@ -198,19 +195,17 @@ where
                 )))
             }
         };
-        let format_specific = if let Some(next_token) = tokens.clone().next() {
-            if next_token.starts_with('{') {
-                let fs_str = tokens
-                    .next()
-                    .ok_or_else(|| serde::de::Error::custom("Expected format specific JSON"))?;
-                serde_json::from_str(fs_str).map_err(|e| {
-                    serde::de::Error::custom(format!("Invalid format specific JSON: {}", e))
-                })?
-            } else {
-                FormatSpecific::default()
-            }
+        let (format_specific, next) = if next.trim_start().starts_with('{') {
+            let json = next.trim_start();
+            let mut values = serde_json::Deserializer::from_str(json).into_iter::<FormatSpecific>();
+            let format_specific = values
+                .next()
+                .transpose()
+                .map_err(serde::de::Error::custom)?
+                .ok_or_else(|| serde::de::Error::custom("Expected format specific JSON"))?;
+            (format_specific, &json[values.byte_offset()..])
         } else {
-            FormatSpecific::default()
+            (FormatSpecific::default(), next)
         };
         nodes.push(crate::common::Node {
             x,
@@ -219,8 +214,18 @@ where
             smooth,
             format_specific,
         });
+        remaining = next;
     }
     Ok(nodes)
+}
+
+fn take_node_token(input: &str) -> Option<(&str, &str)> {
+    let input = input.trim_start();
+    if input.is_empty() {
+        return None;
+    }
+    let end = input.find(char::is_whitespace).unwrap_or(input.len());
+    Some((&input[..end], &input[end..]))
 }
 
 pub(crate) fn is_zero<T>(f: &T) -> bool

--- a/babelfont/src/shape.rs
+++ b/babelfont/src/shape.rs
@@ -763,6 +763,37 @@ mod tests {
     }
 
     #[test]
+    fn test_path_serde_roundtrip_with_whitespace_in_node_format_specific() {
+        let mut format_specific = FormatSpecific::default();
+        format_specific.insert_json(
+            "metadata",
+            &serde_json::json!({
+                "label": "name with spaces, braces { }, and \"quotes\"",
+                "nested": ["one two", { "three": "four five" }]
+            }),
+        );
+        let path = Path {
+            nodes: vec![
+                Node {
+                    x: 0.0,
+                    y: 0.0,
+                    nodetype: NodeType::Move,
+                    smooth: false,
+                    format_specific,
+                },
+                Node::new_line(100.0, 0.0),
+            ],
+            closed: false,
+            format_specific: FormatSpecific::default(),
+        };
+
+        let serialized = serde_json::to_string(&path).unwrap();
+        let deserialized: Path = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, path);
+    }
+
+    #[test]
     fn test_to_kurbo() {
         let path: Path = serde_json::from_str(r#"
             {


### PR DESCRIPTION
## Summary

`serialize_nodes` emits each node's optional `format_specific` as JSON, but `deserialize_nodes` previously consumed it with `split_whitespace()`. Valid JSON values containing whitespace inside strings were therefore split before they reached `serde_json`.

This replaces the node-token loop with cursor-based token parsing and uses `serde_json::Deserializer` to consume exactly one optional `FormatSpecific` value. The stream offset resumes parsing at the following node.

## Compatibility

- Keeps the existing compact node-string format unchanged.
- Continues to accept existing strings without `format_specific`.
- Correctly handles nested JSON, whitespace, braces, and escaped quotes in per-node `format_specific`.

## Tests

- Added a `Path` serde round-trip regression whose first node contains whitespace, braces, nested JSON, and escaped quotes in `format_specific`, followed by a second node.
- `cargo fmt --check` passes.
- `cargo test -p babelfont test_path_serde_roundtrip` passes (2 tests).
- The full `cargo test -p babelfont` run has 12 pre-existing fixture failures caused by absent `designspace.json` / RobocJK / FontForge fixture data; 77 tests pass, including the affected serde tests.