### PR TITLE
SFD name strings: decode UTF-7 correctly, emit featureNames records validly

### DIFF
--- a/babelfont/src/convertors/fontforge.rs
+++ b/babelfont/src/convertors/fontforge.rs
@@ -35,11 +35,6 @@ static CHAIN_POSSUB_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Matches: (coverage|class|glyph) "<subtable name>" <n1> <n2> <n3> <nRules>
     Regex::new(r#"(coverage|class|glyph)\s+"([^"]*)"\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)"#).unwrap()
 });
-static FEATURE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    // Expected format: '<feature tag>' <language code> "<feature name>"
-    #[allow(clippy::unwrap_used)] // Safe because the regex is valid
-    Regex::new(r#"'(?P<tag>.{4})'\s+(?P<lang>\d+)\s+"(?P<name>.+)""#).unwrap()
-});
 
 const GENERATED_KERN_SUBTABLE: &str = "generated_kern";
 const HEADER_VERSION_KEY: &str = "sfd.splinefontdb_version";
@@ -602,21 +597,29 @@ impl SfdParser {
                 }
                 "OtfFeatName" => {
                     if let Some(v) = &value {
-                        // Expected format: '<feature tag>' <language code> "<feature name>"
-                        let regex = &FEATURE_NAME_REGEX;
-                        if let Some(caps) = regex.captures(v) {
-                            let tag = caps.name("tag").map(|m| m.as_str()).unwrap_or_default();
-                            let lang_id = caps
-                                .name("lang")
-                                .and_then(|m| m.as_str().parse::<u32>().ok())
-                                .unwrap_or(0);
-                            let name = caps.name("name").map(|m| m.as_str()).unwrap_or_default();
+                        // '<feature tag>' followed by one `<language id> "<name>"` pair
+                        // per language. The names are UTF-7, quotes included, so the
+                        // quote characters on the line are always delimiters.
+                        let tokens = Self::tokenize_preserving_quotes(v);
+                        let mut it = tokens.iter();
+                        let tag = it
+                            .next()
+                            .map(|t| t.trim_matches('\''))
+                            .unwrap_or_default()
+                            .to_string();
+                        let mut parsed_any = false;
+                        while let (Some(lang), Some(name)) = (it.next(), it.next()) {
+                            let Ok(lang_id) = lang.parse::<u32>() else {
+                                break;
+                            };
+                            parsed_any = true;
                             self.feature_names
-                                .entry(tag.into())
+                                .entry(tag.as_str().into())
                                 .or_default()
-                                .push((lang_id, name.to_string()));
-                        } else {
-                            println!("Warning: invalid OTFeatureName format: {}", v);
+                                .push((lang_id, decode_utf7(name.trim_matches('"'))));
+                        }
+                        if !parsed_any {
+                            log::warn!("invalid OtfFeatName line: {v}");
                         }
                     }
                 }
@@ -3258,6 +3261,24 @@ impl SfdParser {
             .collect::<String>()
     }
 
+    /// Escape a string for a quoted Windows-platform FEA name: anything outside
+    /// printable ASCII, plus the quote and backslash, becomes a `\XXXX` escape of
+    /// its UTF-16 code units.
+    fn fea_string_escape(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for c in s.chars() {
+            if (' '..='~').contains(&c) && c != '"' && c != '\\' {
+                out.push(c);
+            } else {
+                let mut units = [0u16; 2];
+                for unit in c.encode_utf16(&mut units) {
+                    out.push_str(&format!("\\{unit:04X}"));
+                }
+            }
+        }
+        out
+    }
+
     fn insert_gtables(&mut self) {
         // Collect all lookup names referenced by chain/context entries.
         // These must be emitted before the chain/context lookups that reference them.
@@ -3518,7 +3539,13 @@ impl SfdParser {
                 feature.code = "featureNames {\n".to_string()
                     + (names
                         .iter()
-                        .map(|(lang_id, name)| format!("    name 3 1 {} \"{}\";\n", lang_id, name))
+                        .map(|(lang_id, name)| {
+                            format!(
+                                "    name 3 1 {} \"{}\";\n",
+                                lang_id,
+                                Self::fea_string_escape(name)
+                            )
+                        })
                         .collect::<String>()
                         .as_str())
                     + "};\n"

--- a/babelfont/src/convertors/fontforge/utf7.rs
+++ b/babelfont/src/convertors/fontforge/utf7.rs
@@ -36,7 +36,15 @@ pub fn decode_utf7(s: &str) -> String {
                 // UTF-8 happens to "work" for ASCII -- "This" encodes to
                 // 00 54 00 68 00 69 00 73, which IS valid UTF-8 -- but every
                 // character arrives preceded by a NUL.
-                for unit in char::decode_utf16(decode_modified_base64(&b64)) {
+                //
+                // FontForge's writer encodes its C string's NUL terminator into
+                // the run as a full zero unit; its own reader discards it, and
+                // an embedded U+0000 is never content, so it is dropped here.
+                let units: Vec<u16> = decode_modified_base64(&b64)
+                    .into_iter()
+                    .filter(|&u| u != 0)
+                    .collect();
+                for unit in char::decode_utf16(units) {
                     result.push(unit.unwrap_or(char::REPLACEMENT_CHARACTER));
                 }
             }
@@ -195,7 +203,7 @@ mod tests {
     #[test]
     fn real_corpus_strings() {
         // librefonts/corben's LangName.
-        assert_eq!(decode_utf7("Corben.+AAoACgAA-This"), "Corben.\n\n\u{0}This");
+        assert_eq!(decode_utf7("Corben.+AAoACgAA-This"), "Corben.\n\nThis");
         // librefonts/aguafinascript's OFL description, CR-separated.
         assert_eq!(decode_utf7("License,+AA0A-Version"), "License,\rVersion");
     }
@@ -220,6 +228,20 @@ mod tests {
             decode_utf7("+BCEEPgRHBDUEQgQwBD0EOARP +BEEA +BD0EOAQ2BD0ENQQ5"),
             "\u{421}\u{43e}\u{447}\u{435}\u{442}\u{430}\u{43d}\u{438}\u{44f} \u{441} \u{43d}\u{438}\u{436}\u{43d}\u{435}\u{439}"
         );
+    }
+
+    #[test]
+    fn the_writers_nul_terminator_is_not_content() {
+        // FontForge encodes its C string's trailing NUL into the run: Monomakh's
+        // "+BE8ENwRLBDoEMAAA" is five Cyrillic letters and one zero unit. The
+        // shipped binary and FontForge's own FEA export both carry the five
+        // letters and no NUL.
+        let decoded = decode_utf7("+BE8ENwRLBDoEMAAA");
+        assert_eq!(
+            decoded, "\u{44f}\u{437}\u{44b}\u{43a}\u{430}",
+            "the zero unit is a terminator artifact, not content"
+        );
+        assert!(!decoded.contains('\0'));
     }
 
     #[test]

--- a/babelfont/src/convertors/fontforge/utf7.rs
+++ b/babelfont/src/convertors/fontforge/utf7.rs
@@ -15,11 +15,18 @@ pub fn decode_utf7(s: &str) -> String {
                     continue;
                 }
             }
+            // A run ends at '-' (consumed) or at the first character outside the
+            // base64 alphabet (kept: it is literal text). Reading past that point
+            // folds the terminator and the next run into this one, and any residual
+            // bits then shift every unit that follows.
             let mut b64 = String::new();
             while let Some(&b64_ch) = chars.peek() {
                 if b64_ch == '-' {
                     chars.next(); // consume '-'
                     break;
+                }
+                if !b64_ch.is_ascii() || INVERSE_LOOKUP[b64_ch as usize] == 255 {
+                    break; // literal text: leave it for the outer loop
                 }
                 b64.push(b64_ch);
                 chars.next(); // consume base64 char
@@ -203,5 +210,20 @@ mod tests {
     fn lone_surrogate_becomes_the_replacement_character() {
         // A high surrogate with no low surrogate must not panic.
         assert_eq!(decode_utf7("+2DQ-"), "\u{FFFD}");
+    }
+    #[test]
+    fn a_run_ends_at_the_first_non_base64_character() {
+        // FontForge writes one run per word, separated by literal spaces, and a
+        // run's residual bits must not leak into the next: this is Russian
+        // "Sochetaniya s nizhney", three runs, two literal spaces.
+        assert_eq!(
+            decode_utf7("+BCEEPgRHBDUEQgQwBD0EOARP +BEEA +BD0EOAQ2BD0ENQQ5"),
+            "\u{421}\u{43e}\u{447}\u{435}\u{442}\u{430}\u{43d}\u{438}\u{44f} \u{441} \u{43d}\u{438}\u{436}\u{43d}\u{435}\u{439}"
+        );
+    }
+
+    #[test]
+    fn a_dash_terminated_run_consumes_the_dash() {
+        assert_eq!(decode_utf7("+BEE-x"), "\u{441}x");
     }
 }


### PR DESCRIPTION
Three commits, one theme: strings from an SFD reaching the compiled name table.

**A base64 run ends at the first non-base64 character**, not only at `-`.
The decoder read past that boundary, folding the literal spaces FontForge
writes between words into the run, and each run's residual bits shifted every
unit after it. Nine of 121 corpus fonts carried the resulting mojibake in
their copyright, designer-name or embedded OFL strings -- BreeSerif's
"Veronika Burian, JosI..." garbage is this bug -- long read as source damage.

**The writer's NUL terminator is not content.** FontForge encodes its C
string's trailing NUL into some runs as a full zero unit; its own reader
discards it. Ours kept it, so decoded names carried embedded U+0000 into the
compiled name table. The corpus test had enshrined the artifact
("Corben.\n\n\0This"); its expectation now matches FontForge's reader.

**One `name` statement per OtfFeatName record.** The line holds one
`<language id> "<name>"` pair per language, and a greedy regex swallowed them
all into a single invalid statement -- the reason Monomakh could not be
compiled at all. The line is tokenized into its pairs, each decoded, and
non-ASCII is written as \XXXX escapes of UTF-16 code units, as a quoted
Windows-platform FEA string requires.

Monomakh now compiles with all 18 feature-name records intact, Russian names
byte-for-byte per an independent reference decode, and zero embedded NULs --
matching its shipped FontForge binary.