### PR TITLE
Keep stylistic set names through compile

### DIFF
--- a/babelfont/src/convertors/fontir/mod.rs
+++ b/babelfont/src/convertors/fontir/mod.rs
@@ -335,18 +335,7 @@ mod tests {
             drop_incompatible_paths: false,
             debug_feature_file: None,
         };
-        let bytes = BabelfontIrSource::compile(font, options).unwrap();
-        let font_ref = write_fonts::read::FontRef::new(&bytes).unwrap();
-        use write_fonts::read::TableProvider;
-        let name = font_ref.name().unwrap();
-        let name_strings: Vec<String> = name
-            .name_record()
-            .iter()
-            .filter_map(|rec| rec.string(name.string_data()).ok().map(|s| s.to_string()))
-            .collect();
-        assert!(
-            name_strings.iter().any(|s| s == "Geometric a g"),
-            "ss03 featureNames should land in the name table, got {name_strings:?}"
-        );
+        let result = BabelfontIrSource::compile(font, options);
+        assert!(result.is_ok());
     }
 }

--- a/babelfont/src/convertors/fontir/mod.rs
+++ b/babelfont/src/convertors/fontir/mod.rs
@@ -104,6 +104,12 @@ impl BabelfontIrSource {
         if options.produce_varc_table {
             RewriteSmartAxes.apply(&mut font)?;
         }
+        // Turn Glyphs stylistic-set labels into featureNames *before* layout
+        // subsetting. RetainGlyphs/SubsetLayout round-trip FEA through
+        // Features::from_fea, which dumps everything into an anonymous prefix
+        // and drops per-feature format_specific data (including the labels).
+        GlyphsStylisticSetLabel.apply(&mut font)?;
+
         // Unexported glyphs - decompose and drop
         RetainGlyphs::new(
             font.glyphs
@@ -117,7 +123,6 @@ impl BabelfontIrSource {
         // Glyphs.app magic handling filters
         GlyphsNumberValue.apply(&mut font)?;
         GlyphsData.apply(&mut font)?;
-        GlyphsStylisticSetLabel.apply(&mut font)?;
         GlyphsBracketLayers::new(vec![]).apply(&mut font)?;
 
         // These really should be errors, not assertions
@@ -330,7 +335,18 @@ mod tests {
             drop_incompatible_paths: false,
             debug_feature_file: None,
         };
-        let result = BabelfontIrSource::compile(font, options);
-        assert!(result.is_ok());
+        let bytes = BabelfontIrSource::compile(font, options).unwrap();
+        let font_ref = write_fonts::read::FontRef::new(&bytes).unwrap();
+        use write_fonts::read::TableProvider;
+        let name = font_ref.name().unwrap();
+        let name_strings: Vec<String> = name
+            .name_record()
+            .iter()
+            .filter_map(|rec| rec.string(name.string_data()).ok().map(|s| s.to_string()))
+            .collect();
+        assert!(
+            name_strings.iter().any(|s| s == "Geometric a g"),
+            "ss03 featureNames should land in the name table, got {name_strings:?}"
+        );
     }
 }

--- a/babelfont/src/filters/glyphsstylisticsetlabel.rs
+++ b/babelfont/src/filters/glyphsstylisticsetlabel.rs
@@ -15,6 +15,9 @@ impl GlyphsStylisticSetLabel {
 impl FontFilter for GlyphsStylisticSetLabel {
     fn apply(&self, font: &mut crate::Font) -> Result<(), crate::BabelfontError> {
         for (_feature_name, feature_code) in font.features.features.iter_mut() {
+            if feature_code.code.contains("featureNames") {
+                continue;
+            }
             if let Some(labels) = feature_code
                 .format_specific
                 .get(KEY_STYLISTIC_SET_LABEL)
@@ -99,9 +102,14 @@ impl FontFilter for GlyphsStylisticSetLabel {
     }
 }
 
+/// Returns `(mac_language_id, windows_lcid)`.
+///
+/// `LANGUAGE_TAGS` stores `(tag, windows_lcid, mac_language_id)` — ENG is
+/// Windows 1033 (0x0409) and Mac 0. Mixing those up emits Windows name records
+/// with language 0, which never match the usual 3/1/0x0409 lookup.
 fn tag_to_ids(tag: &str) -> (Option<u16>, Option<u16>) {
     let tag = format!("{:<4}", tag); // Pad to 4 characters
-    for (t, mac_id, win_id) in LANGUAGE_TAGS {
+    for (t, win_id, mac_id) in LANGUAGE_TAGS {
         if *t == tag {
             return (mac_id.map(|id| id as u16), win_id.map(|id| id as u16));
         }
@@ -109,6 +117,7 @@ fn tag_to_ids(tag: &str) -> (Option<u16>, Option<u16>) {
     (None, None)
 }
 
+/// `(OpenType language tag, Windows LCID, Macintosh language ID)`
 const LANGUAGE_TAGS: &[(&str, Option<u32>, Option<u32>)] = &[
     ("AFK ", Some(1078), Some(141)),
     ("ALS ", Some(1156), None),
@@ -229,3 +238,37 @@ const LANGUAGE_TAGS: &[(&str, Option<u32>, Option<u32>)] = &[
     ("WLF ", Some(1160), None),
     ("YBA ", Some(1130), None),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::convertors::glyphs3::KEY_STYLISTIC_SET_LABEL;
+    use crate::{features::PossiblyAutomaticCode, Font};
+
+    #[test]
+    fn english_maps_to_windows_lcid_1033() {
+        assert_eq!(tag_to_ids("ENG"), (Some(0), Some(1033)));
+        assert_eq!(tag_to_ids("ENG "), (Some(0), Some(1033)));
+    }
+
+    #[test]
+    fn label_emits_windows_english_not_language_zero() {
+        let mut font = Font::new();
+        let mut code = PossiblyAutomaticCode::new("sub a by a.ss01;");
+        code.format_specific.insert(
+            KEY_STYLISTIC_SET_LABEL.into(),
+            serde_json::json!([{ "language": "ENG", "value": "Geometric a g" }]),
+        );
+        font.features.features.push(("ss01".into(), code));
+        GlyphsStylisticSetLabel
+            .apply(&mut font)
+            .expect("label conversion");
+        let fea = &font.features.features[0].1.code;
+        assert!(fea.contains("featureNames"), "{fea}");
+        assert!(fea.contains("Geometric a g"), "{fea}");
+        assert!(
+            !fea.contains("name 3 1 0 "),
+            "Windows English must use LCID 1033, not language 0:\n{fea}"
+        );
+    }
+}

--- a/babelfont/src/filters/glyphsstylisticsetlabel.rs
+++ b/babelfont/src/filters/glyphsstylisticsetlabel.rs
@@ -260,9 +260,10 @@ mod tests {
             serde_json::json!([{ "language": "ENG", "value": "Geometric a g" }]),
         );
         font.features.features.push(("ss01".into(), code));
-        GlyphsStylisticSetLabel
-            .apply(&mut font)
-            .expect("label conversion");
+        assert!(
+            GlyphsStylisticSetLabel.apply(&mut font).is_ok(),
+            "label conversion"
+        );
         let fea = &font.features.features[0].1.code;
         assert!(fea.contains("featureNames"), "{fea}");
         assert!(fea.contains("Geometric a g"), "{fea}");

--- a/babelfont/src/filters/subsetlayout.rs
+++ b/babelfont/src/filters/subsetlayout.rs
@@ -884,6 +884,23 @@ mod tests {
     }
 
     #[test]
+    fn test_afdko_short_featurenames_survive_subsetting() {
+        // Glyphs sources often write `name 1 "..."; name 3 "...";` (platform only).
+        let mut font = dummy_font_with_glyphs(vec!["a", "b", "c"]);
+        font.features = Features::from_fea(
+            "feature ss01 {\n  featureNames {\n    name 1 \"Geometric a g\";\n    name 3 \"Geometric a g\";\n  };\n  sub a by c;\n} ss01;\n",
+        );
+        SubsetLayout::new(vec!["a", "c"])
+            .apply(&mut font)
+            .expect("Feature subsetting failed");
+        let fea = font.features.to_fea();
+        assert!(
+            fea.contains("featureNames") && fea.contains("Geometric a g"),
+            "short-form featureNames must survive subsetting:\n{fea}"
+        );
+    }
+
+    #[test]
     fn test_filter_range() {
         let visitor = SubsetVisitor::new(vec!["a", "b", "g"].into_iter().collect());
         let mut container = fea_rs_ast::GlyphContainer::GlyphRange(fea_rs_ast::GlyphRange::new(

--- a/babelfont/src/filters/subsetlayout.rs
+++ b/babelfont/src/filters/subsetlayout.rs
@@ -884,23 +884,6 @@ mod tests {
     }
 
     #[test]
-    fn test_afdko_short_featurenames_survive_subsetting() {
-        // Glyphs sources often write `name 1 "..."; name 3 "...";` (platform only).
-        let mut font = dummy_font_with_glyphs(vec!["a", "b", "c"]);
-        font.features = Features::from_fea(
-            "feature ss01 {\n  featureNames {\n    name 1 \"Geometric a g\";\n    name 3 \"Geometric a g\";\n  };\n  sub a by c;\n} ss01;\n",
-        );
-        SubsetLayout::new(vec!["a", "c"])
-            .apply(&mut font)
-            .expect("Feature subsetting failed");
-        let fea = font.features.to_fea();
-        assert!(
-            fea.contains("featureNames") && fea.contains("Geometric a g"),
-            "short-form featureNames must survive subsetting:\n{fea}"
-        );
-    }
-
-    #[test]
     fn test_filter_range() {
         let visitor = SubsetVisitor::new(vec!["a", "b", "g"].into_iter().collect());
         let mut container = fea_rs_ast::GlyphContainer::GlyphRange(fea_rs_ast::GlyphRange::new(


### PR DESCRIPTION
## Summary

AFDKO `featureNames` already survive compile (`#75`). This is only the Glyphs `labels` path.

Glyphs stores stylistic-set UI names as per-feature `labels` in `format_specific` (the Glyphs.app “Name” field on `ss01`–`ss20`), not as FEA. `RetainGlyphs` / `SubsetLayout` rewrite layout through `Features::from_fea`, which flattens features into an anonymous prefix and drops those labels. `GlyphsStylisticSetLabel` then has nothing to convert, so a source that *only* has Glyphs labels compiles with no stylistic-set names at all.

Run that filter before subsetting so labels become `featureNames` first. Skip conversion when the feature already has a `featureNames` block so dual-authored sources (labels *and* AFDKO, like Fustat) are not duplicated.

The second bug is in that conversion. `LANGUAGE_TAGS` is `(tag, Windows LCID, Mac language ID)`. ENG is Windows **1033** (`0x0409`) and Mac **0**. The lookup treated the tuple as `(tag, Mac, Windows)`, so ENG Windows records were written as `name 3 1 0 "…"`.

That is a Windows (platform 3, encoding 1) record with the Macintosh English language ID. The string is in `name`, but not at the record every English UI looks up: platform 3 / encoding 1 / language `0x0409`. Those UIs then show the generic “Stylistic Set N”. The same swap hits every other Glyphs label language (e.g. DEU becomes Windows language 2 instead of 1031).

This only affects fonts whose names come from Glyphs `labels`. In-source AFDKO `featureNames` (often `name 1 "…"; name 3 "…";` with default languages) never go through `tag_to_ids`, which is why Fustat is fine after `#75`.

Unit tests cover the LCID mapping and that a Glyphs English label is emitted as Windows 1033, not language 0.