### PR TITLE
UFO and TTF: convert the italic angle to the internal convention

### DIFF
--- a/babelfont/src/convertors/fontir/mod.rs
+++ b/babelfont/src/convertors/fontir/mod.rs
@@ -318,6 +318,32 @@ mod tests {
     use crate::convertors::fontir::{BabelfontIrSource, CompilationOptions};
 
     #[test]
+    fn test_compiled_italic_angle_matches_the_source() {
+        // Ibarra Real Nova Italic's UFO says italicAngle -22 and its shipped
+        // Google Fonts binary says post.italicAngle -22. An odd number of
+        // convention flips anywhere in the chain ships +22, a back-slant.
+        let font = crate::load("resources/IbarraRealNova-Italic.ufo").unwrap();
+        let bytes = BabelfontIrSource::compile(font, CompilationOptions::default()).unwrap();
+        let fontref = write_fonts::read::FontRef::new(&bytes).unwrap();
+        use write_fonts::read::TableProvider;
+        let angle = fontref.post().unwrap().italic_angle().to_f32();
+        assert_eq!(angle, -22.0, "post.italicAngle must match the source");
+
+        // And reading that binary back stores the Glyphs convention again.
+        let dir = tempfile::tempdir().unwrap();
+        let ttf = dir.path().join("ital.ttf");
+        std::fs::write(&ttf, &bytes).unwrap();
+        let reloaded = crate::load(ttf).unwrap();
+        assert_eq!(
+            reloaded.masters[0]
+                .metrics
+                .get(&crate::MetricType::ItalicAngle),
+            Some(&22),
+            "the TTF reader must convert post back to the internal convention"
+        );
+    }
+
+    #[test]
     fn test_fustat_skipmetrics() {
         let font = crate::load("resources/Fustat.glyphs").unwrap();
         let options = CompilationOptions {

--- a/babelfont/src/convertors/ttf.rs
+++ b/babelfont/src/convertors/ttf.rs
@@ -258,9 +258,11 @@ fn load_metrics(
         fontref.hhea()?.descender().to_i16() as i32,
     );
 
+    // post stores the angle negative for a right lean; babelfont stores the
+    // Glyphs convention, the opposite sign.
     metrics.insert(
         MetricType::ItalicAngle,
-        fontref.post()?.italic_angle().to_f32() as i32,
+        -fontref.post()?.italic_angle().to_f32() as i32,
     );
     Ok(metrics)
 }

--- a/babelfont/src/convertors/ufo.rs
+++ b/babelfont/src/convertors/ufo.rs
@@ -498,7 +498,8 @@ pub(crate) fn save_info(info: &mut norad::FontInfo, font: &Font, master_ix: usiz
         .map(|m| m.guides.iter().flat_map(|g| g.try_into()).collect())
         .unwrap_or_default();
     info.guidelines = (!guides.is_empty()).then_some(guides);
-    info.italic_angle = get_metric(MetricType::ItalicAngle);
+    // Written back in the UFO's post convention: see load_master_info.
+    info.italic_angle = get_metric(MetricType::ItalicAngle).map(|v| -v);
     // macintoshFONDName, yey
     info.note = font.note.clone();
     // gasp range records
@@ -643,7 +644,12 @@ pub(crate) fn load_master_info(master: &mut Master, info: &norad::FontInfo) {
     load_metric!(info, metrics, ascender, MetricType::Ascender);
     load_metric!(info, metrics, cap_height, MetricType::CapHeight);
     load_metric!(info, metrics, descender, MetricType::Descender);
-    load_metric!(info, metrics, italic_angle, MetricType::ItalicAngle);
+    // A UFO stores the italic angle in the post convention, negative for a
+    // right lean; babelfont stores the Glyphs convention, the opposite sign
+    // (compare glyphsLib masters.py, `italic_angle = -master.italicAngle`).
+    if let Some(v) = info.italic_angle {
+        metrics.insert(MetricType::ItalicAngle, -v as i32);
+    }
     load_metric!(info, metrics, x_height, MetricType::XHeight);
     load_metric!(
         info,
@@ -1183,6 +1189,34 @@ pub(crate) mod tests {
         assert_eq!(ufo1.data, ufo2.data);
         assert_eq!(ufo1.images, ufo2.images);
         assert_eq!(ufo1.font_info, ufo2.font_info);
+    }
+
+    #[test]
+    fn test_italic_angle_conventions() {
+        // A UFO stores the angle in the post convention, negative for a right
+        // lean; babelfont stores the Glyphs convention, the opposite sign, the
+        // same as glyphsLib's `-master.italicAngle`. Ibarra Real Nova Italic
+        // says -22 in fontinfo, and its shipped binary says -22 in post; kept
+        // raw, both of babelfont's compile paths shipped +22, a back-slant.
+        let font = crate::load("resources/IbarraRealNova-Italic.ufo").unwrap();
+        assert_eq!(
+            font.masters[0].metrics.get(&crate::MetricType::ItalicAngle),
+            Some(&22),
+            "internally the Glyphs convention: right lean is positive"
+        );
+
+        // And back out in the UFO's own convention, unchanged.
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("ital.ufo");
+        font.save(out.clone()).unwrap();
+        let reloaded = crate::load(out).unwrap();
+        assert_eq!(
+            reloaded.masters[0]
+                .metrics
+                .get(&crate::MetricType::ItalicAngle),
+            Some(&22),
+            "a UFO round-trip must preserve the angle"
+        );
     }
 
     #[test]


### PR DESCRIPTION
babelfont stores the italic angle in the Glyphs convention (positive for a right lean); the compilers negate on the way to post, as glyphsLib does. The UFO reader/writer and the TTF reader passed the post-convention value through raw, so UFO and TTF italics came out back-slanted: Ibarra Real Nova Italic's UFO and shipped binary both say -22, babelfont compiled +22.

The three sites now negate, and tests ride the full loop:
UFO (-22) -> internal (+22) -> post (-22) -> TTF read back (+22) -> UFO written again (-22).

The VFB and VFJ readers also store the angle raw, but their formats' convention is unverified, so they are left for a follow-up.