### PR TITLE
glyphs3: do not drop English-only singular properties

### DIFF
--- a/babelfont/src/convertors/glyphs3.rs
+++ b/babelfont/src/convertors/glyphs3.rs
@@ -496,10 +496,13 @@ fn load_properties(
 fn save_properties(names: &Names, custom_ot_values: &CustomOTValues) -> Vec<glyphs3::Property> {
     let mut properties: Vec<glyphs3::Property> = vec![];
 
-    // Macro for singular-only properties (no localized variant)
+    // Macro for singular-only properties (no localized variant). These
+    // cannot carry a localization, so a name that exists only under a
+    // language tag (an SFD's LangName strings live under ENG) must fall
+    // back to it rather than be dropped.
     macro_rules! push_singular {
         ($field:expr, $key:expr) => {
-            if let Some(value) = $field.get_default() {
+            if let Some(value) = $field.get_default_or_fallback() {
                 properties.push(glyphs3::Property::SingularProperty {
                     key: $key,
                     value: value.clone(),
@@ -1231,6 +1234,45 @@ fn save_master(
 #[allow(clippy::unwrap_used, clippy::indexing_slicing)]
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn english_only_singular_properties_are_not_dropped() {
+        // An SFD's LangName strings populate the names under the ENG tag,
+        // not the default; the singular Glyphs properties (the URLs among
+        // them) must fall back to that instead of vanishing. Verified
+        // against the Google Fonts corpus: 119 of 121 shipped fonts carry a
+        // license URL that the converted .glyphs lost this way.
+        let mut font = crate::Font::new();
+        font.names
+            .designer_url
+            .insert("ENG".to_string(), "http://example.com/d".to_string());
+        font.names
+            .license_url
+            .insert("ENG".to_string(), "http://scripts.sil.org/OFL".to_string());
+        font.names
+            .manufacturer_url
+            .insert("ENG".to_string(), "http://example.com/m".to_string());
+        let props = super::save_properties(&font.names, &font.custom_ot_values);
+        let singulars: Vec<_> = props
+            .iter()
+            .filter_map(|p| match p {
+                glyphslib::glyphs3::Property::SingularProperty { key, value } => {
+                    Some((format!("{:?}", key), value.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        for (key, value) in [
+            ("DesignerUrl", "http://example.com/d"),
+            ("LicenseUrl", "http://scripts.sil.org/OFL"),
+            ("ManufacturerUrl", "http://example.com/m"),
+        ] {
+            assert!(
+                singulars.iter().any(|(k, v)| k == key && v == value),
+                "missing singular property {key}: got {singulars:?}"
+            );
+        }
+    }
+
     #[test]
     fn font_level_os2_classes_reach_the_exported_instance() {
         // The Glyphs format carries usWeightClass/usWidthClass on instances.

--- a/babelfont/src/i18ndictionary.rs
+++ b/babelfont/src/i18ndictionary.rs
@@ -28,6 +28,24 @@ impl I18NDictionary {
         self.0.insert(DFLT.to_string(), s);
     }
 
+    /// The default string, falling back to English, then to a sole entry.
+    ///
+    /// For output fields that cannot carry a localization (e.g. Glyphs 3
+    /// singular properties), a dictionary populated only under a language
+    /// tag -- as an SFD's `LangName` strings are, under `ENG` -- still has
+    /// an obvious best value; returning `None` there silently drops it.
+    pub fn get_default_or_fallback(&self) -> Option<&String> {
+        self.get_default()
+            .or_else(|| self.0.get("ENG"))
+            .or_else(|| {
+                if self.0.len() == 1 {
+                    self.0.values().next()
+                } else {
+                    None
+                }
+            })
+    }
+
     /// Insert a string for a given language code.
     ///
     /// Language codes should be [OpenType Language System Tags](https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags).


### PR DESCRIPTION
An SFD's LangName strings populate the name dictionaries under the ENG tag, but the singular Glyphs properties (designerURL, licenseURL, manufacturerURL among them) were written from get_default(), which reads only the untagged default -- so every English-only value silently vanished on the way to .glyphs. Across the 121-font Google Fonts FontForge corpus this dropped the license URL from 119 fonts, the designer URL from 95 and the vendor URL from 72.

Singular properties cannot carry a localization, so the writer now falls back: default, else English, else a sole entry (new I18NDictionary::get_default_or_fallback, documented). A unit test pins the three URLs; reverting the writer fails it. Verified end-to-end: converting Abel's SFD now emits all three URL properties, and the compiled font carries name IDs 11, 12 and 14 again.